### PR TITLE
support Android M Preview 2

### DIFF
--- a/permissions_checker.py
+++ b/permissions_checker.py
@@ -6,6 +6,8 @@ from xml.etree import ElementTree
 
 
 BLACK_LIST = (
+    'android.permission.READ_EXTERNAL_STORAGE',
+    'android.permission.WRITE_EXTERNAL_STORAGE',
     'android.permission.READ_CALENDAR',
     'android.permission.WRITE_CALENDAR',
     'android.permission.CAMERA',


### PR DESCRIPTION
New permission group STORAGE in Android M Preview 2.
This permission group has `READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_STORAGE`.
User grants or not grants STORAGE permission group at runtime.

![device-2015-07-14-153259](https://cloud.githubusercontent.com/assets/6926816/8667766/b847e2c8-2a3e-11e5-89d1-67388ffa5276.png)
