### PR TITLE
Allow passing directory path to script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,12 @@ Just clone this repository or download the python file.
 
 ## Usage
 
-Only you have to do is just executing below command on your root app directory.
+Simply point the script at your root app directory:
 
 ```sh
-$ cd <root your app>
-$ python permissions_checker.py
+$ python permissions_checker.py /home/user/my-app
 
-> Searching file: /Users/hoge/test/data/AndroidManifest.xml
+> Searching file: /home/user/my-app/src/main/AndroidManifest.xml
 > Unfortunately, you have to handle these permissions in MNC.
 > android.permission.READ_CALENDAR
 > android.permission.WRITE_CALENDAR

--- a/permissions_checker.py
+++ b/permissions_checker.py
@@ -2,6 +2,7 @@
 # !/usr/bin/env python
 
 import os
+import sys
 from xml.etree import ElementTree
 
 
@@ -38,7 +39,8 @@ TARGET_FILE_NAME = 'AndroidManifest.xml'
 def _manifest_files():
     manifests = []
     exclude = "build"
-    for root, dirs, files in os.walk(os.getcwd()):
+    workdir = sys.argv[1] if len(sys.argv) > 1 else os.getcwd()
+    for root, dirs, files in os.walk(workdir):
         if exclude in dirs:
             dirs.remove(exclude)
         for file in files:


### PR DESCRIPTION
Plus a README change to reflect new argument.

The idea behind this is to be able to call:

```
python permissions_checker.py /path/to/appdir
```

Minor convenience since I don't have to copy the script over or accidentally leave it in my app folder.  Submitting a PR in case you find it useful. 
